### PR TITLE
fix typo of: "minimalmodbus"

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ pip install requirement.txt
 ### Packages (requirement.txt)
 ```
 pyserial
-minimialmobdus
+minimalmodbus
 pymodbus
 numpy
 ```

--- a/requirement.txt
+++ b/requirement.txt
@@ -1,4 +1,4 @@
 pyserial
-minimialmobdus
+minimalmodbus
 pymodbus
 numpy


### PR DESCRIPTION
Hi,
There seems to be a typo in the requirement.txt file.
Please, see if this fix is correct.
Thanks.
